### PR TITLE
Piper/issue 42 fix free for all bond

### DIFF
--- a/contracts/Alarm.sol
+++ b/contracts/Alarm.sol
@@ -184,11 +184,18 @@ contract CallerPool {
                 // Check if we are within the free-for-all period.  If so, we
                 // award from all pool members.
                 if (blockWindow + 2 > numWindows) {
-                        for (i = 0; i < pool.length; i++) {
-                                if (pool[i] == toCaller) {
+                        address firstCaller = getDesignatedCaller(callKey, targetBlock, gracePeriod, targetBlock);
+                        for (i = targetBlock; i <= targetBlock + gracePeriod; i += 4) {
+                                fromCaller = getDesignatedCaller(callKey, targetBlock, gracePeriod, i);
+                                if (fromCaller == firstCaller && i != targetBlock) {
+                                        // We have already gone through all of
+                                        // the pool callers so we should break
+                                        // out of the loop.
+                                        break;
+                                }
+                                if (fromCaller == toCaller) {
                                         continue;
                                 }
-                                fromCaller = pool[i];
                                 bonusAmount = _doBondBonusTransfer(fromCaller, toCaller);
 
                                 // Log the bonus was awarded.

--- a/contracts/Testers.sol
+++ b/contracts/Testers.sol
@@ -104,6 +104,7 @@ contract Fails {
                 int x = 1;
                 int y = 0;
                 x / y;
+                value = true;
         }
 
         function scheduleIt(address to) public {

--- a/contracts/Testers.sol
+++ b/contracts/Testers.sol
@@ -101,10 +101,13 @@ contract Fails {
         bytes32 public dataHash;
 
         function doIt() public {
-                int x = 1;
-                int y = 0;
-                x / y;
+                __throw();
                 value = true;
+        }
+
+        function __throw() internal {
+                int[] x;
+                x[1];
         }
 
         function scheduleIt(address to) public {

--- a/tests/call-execution/test_call_that_throws_exception.py
+++ b/tests/call-execution/test_call_that_throws_exception.py
@@ -33,4 +33,4 @@ def test_what_happens_when_call_throws_exception(geth_node, rpc_client, deployed
 
     assert client_contract.value.call() is False
     assert alarm.checkIfCalled.call(callKey) is True
-    assert alarm.checkIfSuccess.call(callKey) is True
+    assert alarm.checkIfSuccess.call(callKey) is False

--- a/tests/call-execution/test_call_that_throws_exception.py
+++ b/tests/call-execution/test_call_that_throws_exception.py
@@ -1,0 +1,36 @@
+from populus.contracts import get_max_gas
+from populus.utils import wait_for_transaction, wait_for_block
+
+
+deploy_max_wait = 15
+deploy_max_first_block_wait = 180
+deploy_wait_for_block = 1
+
+geth_max_wait = 45
+geth_chain_name = "default-test-lower-gas-limit"
+
+
+def test_what_happens_when_call_throws_exception(geth_node, rpc_client, deployed_contracts):
+    alarm = deployed_contracts.Alarm
+    client_contract = deployed_contracts.Fails
+
+    deposit_amount = get_max_gas(rpc_client) * rpc_client.get_gas_price() * 20
+    alarm.deposit.sendTransaction(client_contract._meta.address, value=deposit_amount)
+
+    txn_hash = client_contract.scheduleIt.sendTransaction(alarm._meta.address)
+    wait_for_transaction(client_contract._meta.rpc_client, txn_hash)
+
+    callKey = alarm.getLastCallKey.call()
+    assert callKey is not None
+
+    assert client_contract.value.call() is False
+    assert alarm.checkIfCalled.call(callKey) is False
+    assert alarm.checkIfSuccess.call(callKey) is False
+
+    wait_for_block(rpc_client, alarm.getCallTargetBlock.call(callKey), 300)
+    call_txn_hash = alarm.doCall.sendTransaction(callKey)
+    wait_for_transaction(alarm._meta.rpc_client, call_txn_hash)
+
+    assert client_contract.value.call() is False
+    assert alarm.checkIfCalled.call(callKey) is True
+    assert alarm.checkIfSuccess.call(callKey) is True

--- a/tests/pool/test_free_for_all_call_bonus.py
+++ b/tests/pool/test_free_for_all_call_bonus.py
@@ -62,7 +62,7 @@ def test_free_for_all_window_awards_mega_bonus(geth_node, geth_coinbase, rpc_cli
     assert first_pool_key > 0
 
     # Wait for it to become active
-    wait_for_block(rpc_client, first_pool_key, 180)
+    wait_for_block(rpc_client, first_pool_key, 240)
 
     # We should both be in the pool
     assert caller_pool.getActivePoolKey.call() == first_pool_key


### PR DESCRIPTION
### What was wrong.

Currently, if a call gets to the free-for-all window, instead of awarding the bond bonus from the callers that didn't make their calls, it awards it from all of them (even ones that weren't assigned to that call).

### How was it fixed.

Now it iterates through the block numbers ensuring that it only uses addresses that were part of this call.