### PR TITLE
Doc fixes: CLI

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -24,6 +24,7 @@ The Alarm service is made of the following contracts.
 
 
 .. class:: RequestTracker
+    :noindex:
 
 RequestTracker
 --------------
@@ -44,6 +45,7 @@ This also enables those executing transaction requests to choose which
 
 
 .. class:: RequestFactory
+    :noindex:
 
 RequestFactory
 --------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 
 0.8.0 (unreleased)
------
+------------------
 
 - Full rewrite of all contracts.
 - Support for both time and block based scheduling.

--- a/docs/claiming.rst
+++ b/docs/claiming.rst
@@ -4,6 +4,7 @@ Claiming
 .. contents:: :local:
 
 .. class:: TransactionRequest
+    :noindex:
 
 The Problem
 -----------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -215,21 +215,7 @@ If you are using Go-Ethereum, put the following in ``/etc/supervisord/conf.d/get
     autorestart=true
     autostart=false
 
-
-If you are using Parity, put the following in ``/etc/supervisord/conf.d/parity.conf``
-
-.. code-block:: shell
-
-    [program:parity]
-    command=parity --db-path /data/ethereum --unlock <your-account-address> --password /home/ubuntu/scheduler_password
-    user=ubuntu
-    stdout_logfile=/var/log/supervisor/parity-stdout.log
-    stderr_logfile=/var/log/supervisor/parity-stderr.log
-    autorestart=true
-    autostart=false
-
-
-If you are using Go-Ethereum, put the following in ``/etc/supervisord/conf.d/scheduler-v8.conf``
+and the following in ``/etc/supervisord/conf.d/scheduler-v8.conf``
 
 .. code-block:: shell
 
@@ -243,8 +229,19 @@ If you are using Go-Ethereum, put the following in ``/etc/supervisord/conf.d/sch
     autorestart=true
     autostart=false
 
+If you are using Parity, put the following in ``/etc/supervisord/conf.d/parity.conf``
 
-If you are using Parity, put the following in ``/etc/supervisord/conf.d/scheduler-v8.conf``
+.. code-block:: shell
+
+    [program:parity]
+    command=parity --db-path /data/ethereum --unlock <your-account-address> --password /home/ubuntu/scheduler_password
+    user=ubuntu
+    stdout_logfile=/var/log/supervisor/parity-stdout.log
+    stderr_logfile=/var/log/supervisor/parity-stderr.log
+    autorestart=true
+    autostart=false
+
+and the following in ``/etc/supervisord/conf.d/scheduler-v8.conf``
 
 .. code-block:: shell
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -127,8 +127,10 @@ steps should get an EC2 instance provisioned with the scheduler running.
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Setup an EC2 instance running Ubuntu.  The smallest instance size works fine.
-* Add an extra volume to store your blockchain data.  16GB should be sufficient
-  for the near term future.
+* Add an extra volume to store your blockchain data.  20GB should be sufficient
+  for a short while (after April 2017) if storing the entire history,
+  block-for-block, is not required.  Otherwise, a much larger size should be
+  used.
 * Optionally mark this volume to persist past termination of the instance so
   that you can reuse your blockchain data.
 * Make sure that the security policy leaves `30303` open to connections from
@@ -191,7 +193,7 @@ Install the Alarm client.
 
 * ``mkdir -p ~/alarm-0.8.0``
 * ``cd ~/alarm-0.8.0``
-* ``virtualenv -p /usr/bin/python3.4 env && source env/bin/activate``
+* ``virtualenv -p /usr/bin/python3.5 env && source env/bin/activate``
 * ``pip install setuptools --upgrade``
 * ``pip install ethereum-alarm-clock-client==8.0.0b1``
 
@@ -201,7 +203,7 @@ Install the Alarm client.
 
 Supervisord will be used to manage both ``geth`` and ``eth_alarm``.
 
-If you are using Go-Ethereum put the following in ``/etc/supervisord/conf.d/geth.conf``
+If you are using Go-Ethereum, put the following in ``/etc/supervisord/conf.d/geth.conf``
 
 .. code-block:: shell
 
@@ -214,7 +216,7 @@ If you are using Go-Ethereum put the following in ``/etc/supervisord/conf.d/geth
     autostart=false
 
 
-If you are using Go-Ethereum put the following in ``/etc/supervisord/conf.d/parity.conf``
+If you are using Parity, put the following in ``/etc/supervisord/conf.d/parity.conf``
 
 .. code-block:: shell
 
@@ -227,7 +229,7 @@ If you are using Go-Ethereum put the following in ``/etc/supervisord/conf.d/pari
     autostart=false
 
 
-If you are using Go-Ethereum put the following in ``/etc/supervisord/conf.d/scheduler-v8.conf``
+If you are using Go-Ethereum, put the following in ``/etc/supervisord/conf.d/scheduler-v8.conf``
 
 .. code-block:: shell
 
@@ -242,7 +244,7 @@ If you are using Go-Ethereum put the following in ``/etc/supervisord/conf.d/sche
     autostart=false
 
 
-If you are using Parity put the following in ``/etc/supervisord/conf.d/scheduler-v8.conf``
+If you are using Parity, put the following in ``/etc/supervisord/conf.d/scheduler-v8.conf``
 
 .. code-block:: shell
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -273,6 +273,14 @@ You will also need to send this account a few ether.  A few times the maximum
 transaction cost should be sufficient as this account should always trend
 upwards as it executes requests and receives payment for them.
 
+Don't forget to back up the key file! Go-Ethereum should have put it in
+
+* ``/data/ethereum/keystore/``
+
+and Parity in
+
+* ``/home/ubuntu/.local/share/io.parity.ethereum/keys/``
+
 8. Turn it on
 ^^^^^^^^^^^^^
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -290,7 +290,7 @@ You can monitor these processes with ``tail``
 
 * ``tail -f /var/log/supervisor/geth*.log``
 * ``tail -f /var/log/supervisor/parity*.log``
-* ``tail -f /var/log/supervisor/scheduler-v6*.log``
+* ``tail -f /var/log/supervisor/scheduler-v8*.log``
 
 
 10. System Clock

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,6 @@ Contents:
    scheduler
    cli
    changelog
-   :maxdepth: 1
 
 
 .. _github repository: https://github.com/pipermerriam/ethereum-alarm-clock


### PR DESCRIPTION
* In example `virtualenv` setup command, use Python 3.5 (not 3.4) as interpreter.
* Bump the recommended EBS drive size from 16G to 20G. After a fast-sync with `geth`, a little over 16 GiB is used for me ATM.
* Reorder `supervisord` config examples so that "if using node impl-n X" sections are consecutive, and fix a typo where "Go-Ethereum" is written where "Parity" should be.
* Quell a few (but not all) Sphinx (1.5.5) warnings. Errors are left as-is.
* EDIT: Remind to back up the generated account's key file.

-----

Lizard playing a leaf lute ([from imgur](https://imgur.com/gallery/zKN5q)):

![The lizard leans against the log, dropps the lute in his lap, and starts to sing.](https://i.imgur.com/tPcwPad.jpg)