### PR TITLE
Update dependencies, include asset file in PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,4 @@ include requirements.txt
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
-include alarm_client/assets/v0.8.0.json
+include alarm_client/assets/*.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,4 @@ include requirements.txt
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
-include alarm_client/assets/v8.0.0.json
+include alarm_client/assets/v0.8.0.json

--- a/alarm_client/config.py
+++ b/alarm_client/config.py
@@ -11,7 +11,7 @@ from web3.utils.abi import (
     filter_by_type,
 )
 
-from populus.utils.wait import (
+from populus.wait import (
     Wait,
 )
 from populus.utils.filesystem import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Sphinx>=1.3.1
 sphinx-better-theme>=0.1.4
-populus>=1.2.0
+gevent>=1.1.2
+populus>=1.6.0
 web3>=3.0.2
 eth-testrpc>=0.8.7
 ethereum-tester-client>=1.2.4

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     include_package_data=True,
     py_modules=['eth_alarm_client'],
     install_requires=[
+        "gevent>=1.1.2",
         "populus>=1.2.1",
         "web3>=3.0.2",
         "pylru>=1.0.9",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     py_modules=['eth_alarm_client'],
     install_requires=[
         "gevent>=1.1.2",
-        "populus>=1.2.1",
+        "populus>=1.6.0",
         "web3>=3.0.2",
         "pylru>=1.0.9",
         "python-dotenv>=0.6.0",


### PR DESCRIPTION
### Summary

* Fixes #72, #73, #74.
* Lists `gevent` as a hard dependency.
* Updates to newer Populus.
* Includes a file missing from PyPI distribution.
* Details in commit messages, or (very verbose) in linked issues.

### Notes

* **CI is likely to fail before getting to check these changes** - will see what I can do. Probably safer to fix that first (see issue #77).
* There seems to have been a typo when preparing a PyPI package of `ethereum-alarm-clock-client`: a version of `v8.0.0b1` was tagged, where `v0.8.0b1` was more likely. If this was indeed a mistake, **the release should be yanked**, which may require fiddling with both Github and PyPI.

### Animal picture

A slightly concerned walrus ([via reddit](https://www.reddit.com/r/photoshopbattles/comments/3ai69v/psbattle_walrus_cub/)):

![Young walrus with huge moustache sticks her head out of the water](https://i.imgur.com/5vUa999.jpg)