### PR TITLE
travis: install `solc` dependencies if binary present in cache

### DIFF
--- a/bin/install_solc.sh
+++ b/bin/install_solc.sh
@@ -7,6 +7,7 @@ set -e
 set -u
 
 if [ ! -e solc-versions/solidity-0.3.6/build/solc/solc ] ; then
+    # cache not present (first run or cleared), perform full installation procedure
     wget -O solc.tar.gz "https://github.com/ethereum/solidity/archive/v0.3.6.tar.gz"
     install -d solc-versions
     cd solc-versions
@@ -20,5 +21,9 @@ if [ ! -e solc-versions/solidity-0.3.6/build/solc/solc ] ; then
     chmod +x ../../../solc-versions/solc-0.3.6
     echo "Geth installed at $PWD/solc-0.3.6"
 else
+    # cached version present, just install package dependencies
+    cd solc-versions
+    cd solidity-0.3.6
+    ./scripts/install_deps.sh
     echo "Geth already installed at $PWD/solc/solc-0.3.6"
 fi


### PR DESCRIPTION
`solc` has many library dependencies that are installed from package repositories, but are not cached by Travis between builds. The `solc` sources and built binary are cached, though.

Current custom installation script for `solc` skips installing the dependencies, which results in broken builds.

This PR attempts to install the dependencies.

FIXME: animal pic missing (will add if build passes).